### PR TITLE
fix win32 conda linking

### DIFF
--- a/recipe/0002-link-conda-qt-libs-win.patch
+++ b/recipe/0002-link-conda-qt-libs-win.patch
@@ -1,0 +1,14 @@
+diff --git a/siputils.py b/siputils.py
+index a29300d..89fe76d 100644
+--- a/siputils.py
++++ b/siputils.py
+@@ -887,6 +887,9 @@ class Makefile:
+         if qt5_rename:
+             lib = "Qt5" + lib[2:]
+ 
++        if sys.platform == "win32":
++            lib += '_conda'
++
+         return lib
+ 
+     def optional_list(self, name):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha256: edcd3790bb01938191eef0f6117de0bf56d1136626c0ddb678f3a558d62e41e5
   patches:
     - 0001-Do-not-override-CC-CXX-LINK-in-sipgen-Makefile.patch
+    - 0002-link-conda-qt-libs-win.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This was necessary for me to correctly find & link the Qt libraries on conda-forge (which are renamed to `Qt5XXX_conda`