### PR TITLE
Compile universal binaries for arm64 cross-compilation

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 set -exou
 
-if [[ $(uname) == "Darwin" ]]; then
+if [[ "${target_platform}" == "osx-arm64" ]]; then
     export CFLAGS="$CFLAGS -arch x86_64 -arch arm64"
     export CXXFLAGS="$CXXFLAGS -arch x86_64 -arch arm64"
     export LDFLAGS="$LDFLAGS -arch x86_64 -arch arm64"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,9 @@
 set -exou
 
 if [[ $(uname) == "Darwin" ]]; then
-    export CFLAGS="-arch x86_64 -arch arm64"
-    export CXXFLAGS="-arch x86_64 -arch arm64"
-    export LDFLAGS="-arch x86_64 -arch arm64"
+    export CFLAGS="$CFLAGS -arch x86_64 -arch arm64"
+    export CXXFLAGS="$CXXFLAGS -arch x86_64 -arch arm64"
+    export LDFLAGS="$LDFLAGS -arch x86_64 -arch arm64"
 fi
 
 $PYTHON -m pip install . -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,9 @@
+set -exou
+
+if [[ $(uname) == "Darwin" ]]; then
+    export CFLAGS="-arch x86_64 -arch arm64"
+    export CXXFLAGS="-arch x86_64 -arch arm64"
+    export LDFLAGS="-arch x86_64 -arch arm64"
+fi
+
+$PYTHON -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,10 @@ source:
   sha256: 204f0240db8999a749d638a987b351861843e69239b811ec3d1881412c3706a6
 
 build:
-  number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  number: 1
+  script: "{{ PYTHON }} -m pip install . -vv"  # [not osx]
+  run_exports:
+    - {{ pin_subpackage('sip', max_pin='x.x') }}
   entry_points:
     - sip-distinfo = sipbuild.distinfo.main:main
     - sip-module = sipbuild.module.main:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 1
-  script: "{{ PYTHON }} -m pip install . -vv"  # [not osx]
+  script: "{{ PYTHON }} -m pip install . -vv"  # [win]
   run_exports:
     - {{ pin_subpackage('sip', max_pin='x.x') }}
   entry_points:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is necessary when cross-compiling binaries on arm64, since sip-build will run on a `x86_64` machine.
