### PR TITLE
Remove universal binary compilation

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,3 @@
 set -exou
 
-if [[ "${target_platform}" == "osx-arm64" ]]; then
-    export CFLAGS="$CFLAGS -arch x86_64 -arch arm64"
-    export CXXFLAGS="$CXXFLAGS -arch x86_64 -arch arm64"
-    export LDFLAGS="$LDFLAGS -arch x86_64 -arch arm64"
-fi
-
 $PYTHON -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 204f0240db8999a749d638a987b351861843e69239b811ec3d1881412c3706a6
 
 build:
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . -vv"  # [win]
   run_exports:
     - {{ pin_subpackage('sip', max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is necessary since the packaged binaries resulted to only have x86_64 compatibility, as opposed to x86_64 and arm64.