### PR TITLE
MNT: Changes to sip entry points

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,14 @@ source:
     - patches/0001-pypy-no-ht_cached_keys.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation  # [win]
   run_exports:
     - {{ pin_subpackage('sip', max_pin='x.x') }}
   entry_points:
-    - sip-distinfo = sipbuild.distinfo.main:main
-    - sip-module = sipbuild.module.main:main
+    - sip-distinfo = sipbuild.tools.distinfo:main
+    - sip-module = sipbuild.tools.module:main
     - sip-build = sipbuild.tools.build:main
     - sip-install = sipbuild.tools.install:main
     - sip-sdist = sipbuild.tools.sdist:main
@@ -54,7 +54,12 @@ test:
     - pip
   commands:
     - pip check
+    - sip-distinfo --help
+    - sip-module --help
     - sip-build --help
+    - sip-install --help
+    - sip-sdist --help
+    - sip-wheel --help
   imports:
     - sipbuild
   files:


### PR DESCRIPTION
Some refactorings in SIP 6.8.4 involved changes to the locations of some entry points


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
